### PR TITLE
feat(tilt): Interactive Lesson screen with tell meter and confidence slider

### DIFF
--- a/docs/superpowers/specs/2026-05-02-home-dashboard-design.md
+++ b/docs/superpowers/specs/2026-05-02-home-dashboard-design.md
@@ -1,0 +1,131 @@
+# Home Dashboard — Design Spec
+
+## Goal
+
+Port `Design/screens/home.jsx` to SvelteKit as `src/routes/home/+page.svelte` with real Supabase data.
+
+## Files
+
+### New
+- `src/lib/stores/profile.svelte.ts` — Profile + daily progress store (Svelte 5 runes)
+- `src/routes/home/+page.server.ts` — SSR profile/daily-progress fetch
+- `src/routes/home/+page.svelte` — Home dashboard component
+
+### Modified
+- `src/routes/+layout.svelte` — Add BottomNav for authenticated non-auth routes
+
+## Profile Store
+
+```ts
+interface Profile {
+  username: string | null;
+  avatarUrl: string | null;
+  level: number;
+  xp: number;
+  streakCount: number;
+  lastSessionDate: string | null;
+  onboardingCompleted: boolean;
+  onboardingGoal: string | null;
+  onboardingLevel: string | null;
+  onboardingTime: number | null;
+}
+
+interface DailyProgress {
+  xpEarned: number;
+  sessionsCompleted: number;
+  timeSpentSeconds: number;
+}
+
+interface ProfileStore {
+  profile: Profile | null;
+  dailyProgress: DailyProgress | null;
+  loading: boolean;
+  fetchProfile(userId: string): Promise<void>;
+  fetchDailyProgress(userId: string, date: string): Promise<void>;
+  updateProfile(userId: string, updates: Partial<Profile>): Promise<void>;
+  addXP(userId: string, amount: number): Promise<void>;
+}
+```
+
+- `$state` for profile, dailyProgress, loading
+- `fetchProfile` — `supabase.from('profiles').select('*').eq('id', userId).single()`
+- `fetchDailyProgress` — `supabase.from('daily_progress').select('*').eq('user_id', userId).eq('date', date).single()`
+- `updateProfile` — `supabase.from('profiles').update(updates).eq('id', userId)`
+- `addXP` — Updates both `profiles.xp` and `daily_progress.xp_earned`
+
+## Home Page Sections
+
+### 1. TopBar
+- Left: avatar circle (gradient bg, first letter of username), "Hey, {name}", "Lvl {level} · {levelTitle}"
+- Right: StreakBadge with streak count
+- Uses existing `TopBar.svelte` component
+
+### 2. Daily XP Hero Card
+- Coral gradient background with radial glow
+- "Today" eyebrow
+- Large serif XP counter: `{xpToday}/{dailyGoal} xp`
+- "Keep the streak hot 🔥" subtitle
+- ProgressRing showing percentage
+- "Continue session · {remaining} xp left" primary button
+- Daily goal default: 100 XP (from profile or hardcoded default)
+
+### 3. Hand of the Day
+- Dark gradient card with PlayingCard display (Q♥ J♥)
+- "WED · #284" eyebrow (date-based)
+- "QJ suited on a wet board. Hero or zero?" title
+- Difficulty dots (5 dots)
+- "3 MIN · +50 XP" footer
+- Clickable — navigates to lesson
+
+### 4. Mood Picker
+- 2x2 grid of buttons
+- ⚡ "Just 5 min" / "Quick drill"
+- 🧠 "Feel smart" / "Easy wins"
+- 🔥 "Challenge" / "Hard mode"
+- 🎬 "Replay" / "Last session"
+- Each button navigates to lesson with mood param
+
+### 5. Skill Tree
+- "Your path" eyebrow, "3 / 18 MASTERED" counter
+- 3 rows: Preflop ranges (100%), Continuation betting (65%), River decisions (0%)
+- Each row: color bar, title, status label, progress bar
+- Locked rows at 50% opacity
+- Data from `training_progress` table
+
+### 6. BottomNav
+- Moved to `+layout.svelte` for authenticated routes
+- Active tab: 'today'
+- Uses existing `BottomNav.svelte` component
+
+## Data Flow
+
+1. `+page.server.ts` uses `createServerSupabase` to fetch profile + daily_progress
+2. Returns `PageData` with profile, dailyProgress
+3. `+page.svelte` receives via `$props()` and renders
+4. Client-side profile store for live updates (XP earned during sessions)
+5. `calculateLevel` from gamification module for level title/progress
+
+## Supabase Queries
+
+```sql
+-- Profile
+SELECT * FROM profiles WHERE id = :userId
+
+-- Daily progress
+SELECT * FROM daily_progress WHERE user_id = :userId AND date = :today
+
+-- Training progress (for skill tree)
+SELECT * FROM training_progress WHERE user_id = :userId
+```
+
+## Error Handling
+
+- Profile not found → redirect to /onboarding
+- Supabase error → show skeleton/placeholder, log error
+- No daily progress row → default to { xpEarned: 0, sessionsCompleted: 0, timeSpentSeconds: 0 }
+
+## Testing
+
+- Manual verification: page loads, data displays, BottomNav works
+- TypeScript: `pnpm exec tsc --noEmit` passes
+- Build: `pnpm build` passes

--- a/tilt-app/src/lib/stores/profile.svelte.ts
+++ b/tilt-app/src/lib/stores/profile.svelte.ts
@@ -1,0 +1,138 @@
+import { browser } from '$app/environment';
+import { createClient } from '$lib/supabase';
+
+export interface Profile {
+	id: string;
+	username: string | null;
+	avatar_url: string | null;
+	level: number;
+	xp: number;
+	streak_count: number;
+	last_session_date: string | null;
+	onboarding_completed: boolean;
+	onboarding_goal: string | null;
+	onboarding_level: string | null;
+	onboarding_time: number | null;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface DailyProgress {
+	id: string;
+	user_id: string;
+	date: string;
+	xp_earned: number;
+	sessions_completed: number;
+	time_spent_seconds: number;
+	streak_maintained: boolean;
+}
+
+export interface TrainingProgress {
+	id: string;
+	user_id: string;
+	module_type: string;
+	module_id: string;
+	progress_percent: number;
+	completed_at: string | null;
+}
+
+function createProfileStore() {
+	let profile = $state<Profile | null>(null);
+	let dailyProgress = $state<DailyProgress | null>(null);
+	let trainingProgress = $state<TrainingProgress[]>([]);
+	let loading = $state(true);
+
+	const supabase = browser ? createClient() : null;
+
+	async function fetchProfile(userId: string) {
+		if (!supabase) return;
+		loading = true;
+		const { data, error } = await supabase
+			.from('profiles')
+			.select('*')
+			.eq('id', userId)
+			.single();
+
+		if (!error && data) {
+			profile = data;
+		}
+		loading = false;
+	}
+
+	async function fetchDailyProgress(userId: string, date: string) {
+		if (!supabase) return;
+		const { data, error } = await supabase
+			.from('daily_progress')
+			.select('*')
+			.eq('user_id', userId)
+			.eq('date', date)
+			.maybeSingle();
+
+		if (!error) {
+			dailyProgress = data;
+		}
+	}
+
+	async function fetchTrainingProgress(userId: string) {
+		if (!supabase) return;
+		const { data, error } = await supabase
+			.from('training_progress')
+			.select('*')
+			.eq('user_id', userId);
+
+		if (!error && data) {
+			trainingProgress = data;
+		}
+	}
+
+	async function updateProfile(userId: string, updates: Partial<Profile>) {
+		if (!supabase) return;
+		const { error } = await supabase
+			.from('profiles')
+			.update(updates)
+			.eq('id', userId);
+
+		if (!error && profile) {
+			profile = { ...profile, ...updates };
+		}
+	}
+
+	async function addXP(userId: string, amount: number) {
+		if (!supabase || !profile) return;
+
+		const newXP = profile.xp + amount;
+		await updateProfile(userId, { xp: newXP });
+
+		const today = new Date().toISOString().split('T')[0];
+		if (dailyProgress && dailyProgress.date === today) {
+			const newDailyXP = dailyProgress.xp_earned + amount;
+			await supabase
+				.from('daily_progress')
+				.update({ xp_earned: newDailyXP })
+				.eq('id', dailyProgress.id);
+			dailyProgress = { ...dailyProgress, xp_earned: newDailyXP };
+		}
+	}
+
+	return {
+		get profile() {
+			return profile;
+		},
+		get dailyProgress() {
+			return dailyProgress;
+		},
+		get trainingProgress() {
+			return trainingProgress;
+		},
+		get loading() {
+			return loading;
+		},
+		fetchProfile,
+		fetchDailyProgress,
+		fetchTrainingProgress,
+		updateProfile,
+		addXP
+	};
+}
+
+export const profileStore = createProfileStore();

--- a/tilt-app/src/routes/+layout.svelte
+++ b/tilt-app/src/routes/+layout.svelte
@@ -3,6 +3,7 @@ import '../app.css';
 import { goto } from '$app/navigation';
 import { page } from '$app/state';
 import { auth } from '$lib/stores/auth.svelte';
+import BottomNav from '$lib/components/BottomNav.svelte';
 
 let { children } = $props();
 
@@ -15,6 +16,27 @@ const isAuthRoute = $derived(
 		page.url.pathname.startsWith('/register') ||
 		page.url.pathname.startsWith('/onboarding')
 );
+
+const showBottomNav = $derived(!isAuthRoute && auth.isAuthenticated);
+
+const activeTab = $derived(() => {
+	const path = page.url.pathname;
+	if (path.startsWith('/home') || path === '/') return 'today';
+	if (path.startsWith('/practice')) return 'practice';
+	if (path.startsWith('/replay')) return 'replay';
+	if (path.startsWith('/you') || path.startsWith('/profile')) return 'you';
+	return 'today';
+});
+
+function handleNav(id: string) {
+	const routes: Record<string, string> = {
+		today: '/home',
+		practice: '/practice',
+		replay: '/replay',
+		you: '/you'
+	};
+	goto(routes[id] ?? '/home');
+}
 
 $effect(() => {
 	if (!auth.loading && !auth.isAuthenticated && !isAuthRoute) {
@@ -34,6 +56,9 @@ $effect(() => {
 	</div>
 {:else if isAuthRoute || auth.isAuthenticated}
 	{@render children()}
+	{#if showBottomNav}
+		<BottomNav active={activeTab()} onNavigate={handleNav} />
+	{/if}
 {/if}
 
 <style>

--- a/tilt-app/src/routes/+page.svelte
+++ b/tilt-app/src/routes/+page.svelte
@@ -5,7 +5,7 @@ import { auth } from '$lib/stores/auth.svelte';
 $effect(() => {
 	if (!auth.loading) {
 		if (auth.isAuthenticated) {
-			goto('/onboarding');
+			goto('/home');
 		} else {
 			goto('/login');
 		}

--- a/tilt-app/src/routes/home/+page.svelte
+++ b/tilt-app/src/routes/home/+page.svelte
@@ -1,0 +1,337 @@
+<script lang="ts">
+import { goto } from '$app/navigation';
+import { auth } from '$lib/stores/auth.svelte';
+import { profileStore } from '$lib/stores/profile.svelte';
+import { calculateLevel } from '$lib/core/gamification';
+import TopBar from '$lib/components/TopBar.svelte';
+import StreakBadge from '$lib/components/StreakBadge.svelte';
+import ProgressRing from '$lib/components/ProgressRing.svelte';
+import PlayingCard from '$lib/components/PlayingCard.svelte';
+
+const DAILY_GOAL = 100;
+
+const moods = [
+	{ emoji: '⚡', title: 'Just 5 min', sub: 'Quick drill', bg: 'rgba(255,91,72,0.12)', border: 'rgba(255,91,72,0.3)' },
+	{ emoji: '🧠', title: 'Feel smart', sub: 'Easy wins', bg: 'rgba(233,185,73,0.12)', border: 'rgba(233,185,73,0.3)' },
+	{ emoji: '🔥', title: 'Challenge', sub: 'Hard mode', bg: 'rgba(178,76,228,0.12)', border: 'rgba(178,76,228,0.3)' },
+	{ emoji: '🎬', title: 'Replay', sub: 'Last session', bg: 'rgba(72,180,255,0.12)', border: 'rgba(72,180,255,0.3)' }
+] as const;
+
+const skillTree = [
+	{ title: 'Preflop ranges', progress: 100, status: 'Mastered', color: 'var(--gold)', locked: false },
+	{ title: 'Continuation betting', progress: 65, status: 'In progress', color: 'var(--coral)', locked: false },
+	{ title: 'River decisions', progress: 0, status: 'Locked · Lvl 5', color: 'var(--cream-dim)', locked: true }
+] as const;
+
+$effect(() => {
+	if (!auth.loading && auth.isAuthenticated && auth.user) {
+		const userId = auth.user.id;
+		profileStore.fetchProfile(userId);
+		const today = new Date().toISOString().split('T')[0];
+		profileStore.fetchDailyProgress(userId, today);
+		profileStore.fetchTrainingProgress(userId);
+	}
+});
+
+const profile = $derived(profileStore.profile);
+const dailyProgress = $derived(profileStore.dailyProgress);
+const levelResult = $derived(profile ? calculateLevel(profile.xp) : null);
+const xpToday = $derived(dailyProgress?.xp_earned ?? 0);
+const xpPercent = $derived(Math.round((xpToday / DAILY_GOAL) * 100));
+const streak = $derived(profile?.streak_count ?? 0);
+const username = $derived(profile?.username ?? 'Player');
+const initial = $derived(username.charAt(0).toUpperCase());
+const levelTitle = $derived(levelResult?.levelData.title ?? 'Poker Novice');
+const level = $derived(levelResult?.level ?? 1);
+const xpRemaining = $derived(Math.max(0, DAILY_GOAL - xpToday));
+
+function handleMood(_mood: string) {
+	goto('/lesson');
+}
+</script>
+
+<div class="screen felt-bg">
+	<TopBar>
+		{#snippet left()}
+			<div style="display: inline-flex; align-items: center; gap: 8px;">
+				<div style="width: 36px; height: 36px; border-radius: 999px; background: linear-gradient(135deg, #ff5b48, #e9b949); display: inline-flex; align-items: center; justify-content: center; font-weight: 700; font-size: 14px; color: #2a0a05;">
+					{initial}
+				</div>
+				<div>
+					<div style="font-size: 13px; font-weight: 600;">Hey, {username}</div>
+					<div class="mono" style="font-size: 10px; color: var(--cream-dim); text-transform: uppercase; letter-spacing: 0.1em;">
+						Lvl {level} · {levelTitle}
+					</div>
+				</div>
+			</div>
+		{/snippet}
+		{#snippet right()}
+			<StreakBadge count={streak} />
+		{/snippet}
+	</TopBar>
+
+	<div class="scroll-content">
+		<!-- Daily progress hero -->
+		<div class="hero-card">
+			<div class="hero-glow"></div>
+			<div class="eyebrow">Today</div>
+			<div class="hero-row">
+				<div>
+					<div class="serif hero-xp">
+						{xpToday}<span class="hero-xp-goal">/{DAILY_GOAL} xp</span>
+					</div>
+					<div class="hero-sub">Keep the streak hot 🔥</div>
+				</div>
+				<ProgressRing value={xpPercent} size={64} label="{xpPercent}%" />
+			</div>
+			<button class="btn btn-primary" style="width: 100%; margin-top: 16px;" onclick={() => goto('/lesson')}>
+				Continue session · {xpRemaining} xp left
+			</button>
+		</div>
+
+		<!-- Hand of the Day -->
+		<div class="section">
+			<div class="section-header">
+				<div class="eyebrow">Hand of the Day</div>
+				<div class="mono" style="font-size: 10px; color: var(--gold);">2,847 PLAYING</div>
+			</div>
+			<button type="button" class="hand-card tap" onclick={() => goto('/lesson')}>
+				<div class="hand-cards">
+					<div style="transform: rotate(-8deg);">
+						<PlayingCard rank="Q" suit="♥" size="md" treatment="classic" />
+					</div>
+					<div style="transform: rotate(8deg) translateX(-12px);">
+						<PlayingCard rank="J" suit="♥" size="md" treatment="classic" delay={100} />
+					</div>
+				</div>
+				<div class="eyebrow" style="color: var(--gold);">WED · #284</div>
+				<div class="serif hand-title">
+					QJ suited on a wet board. Hero or zero?
+				</div>
+				<div class="hand-footer">
+					<div class="hand-dots">
+						{#each ['🟢','🟢','🟢','🟡','⚪'] as dot}
+							<span style="font-size: 8px;">{dot}</span>
+						{/each}
+					</div>
+					<div class="mono" style="font-size: 11px; color: var(--cream-dim);">3 MIN · +50 XP</div>
+				</div>
+			</button>
+		</div>
+
+		<!-- Mood picker -->
+		<div class="section">
+			<div class="eyebrow" style="margin-bottom: 12px;">What's the mood?</div>
+			<div class="mood-grid">
+				{#each moods as mood}
+					<button
+						type="button"
+						class="mood-btn"
+						style="background: {mood.bg}; border: 1px solid {mood.border};"
+						onclick={() => handleMood(mood.title)}
+					>
+						<div style="font-size: 22px; margin-bottom: 6px;">{mood.emoji}</div>
+						<div style="font-size: 14px; font-weight: 600;">{mood.title}</div>
+						<div style="font-size: 11px; color: var(--cream-dim);">{mood.sub}</div>
+					</button>
+				{/each}
+			</div>
+		</div>
+
+		<!-- Skill tree -->
+		<div class="section">
+			<div class="section-header">
+				<div class="eyebrow">Your path</div>
+				<div class="mono" style="font-size: 10px; color: var(--cream-dim);">3 / 18 MASTERED</div>
+			</div>
+			<div class="skill-tree">
+				{#each skillTree as skill, i}
+					<div class="skill-row" style="border-top: {i ? '1px solid var(--hairline)' : 'none'}; opacity: {skill.locked ? 0.5 : 1};">
+						<div class="skill-bar" style="background: {skill.color};"></div>
+						<div class="skill-info">
+							<div style="font-size: 15px; font-weight: 600;">{skill.title}</div>
+							<div class="mono" style="font-size: 10px; color: var(--cream-dim); text-transform: uppercase; letter-spacing: 0.08em;">
+								{skill.status}
+							</div>
+						</div>
+						<div class="skill-progress-track">
+							<div class="skill-progress-fill" style="width: {skill.progress}%; background: {skill.color};"></div>
+						</div>
+					</div>
+				{/each}
+			</div>
+		</div>
+	</div>
+</div>
+
+<style>
+	.screen {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		min-height: 100vh;
+		background: var(--felt);
+		overflow: hidden;
+	}
+
+	.scroll-content {
+		padding: 8px 20px 100px;
+		overflow-y: auto;
+		flex: 1;
+	}
+
+	.hero-card {
+		margin-top: 12px;
+		padding: 22px;
+		border-radius: 24px;
+		background: linear-gradient(180deg, rgba(255,91,72,0.18), rgba(255,91,72,0.04));
+		border: 1px solid rgba(255,91,72,0.3);
+		position: relative;
+		overflow: hidden;
+	}
+
+	.hero-glow {
+		position: absolute;
+		top: -20px;
+		right: -20px;
+		width: 100px;
+		height: 100px;
+		border-radius: 50%;
+		background: radial-gradient(circle, rgba(255,91,72,0.25), transparent 70%);
+	}
+
+	.hero-row {
+		display: flex;
+		align-items: flex-end;
+		justify-content: space-between;
+		margin-top: 8px;
+	}
+
+	.hero-xp {
+		font-size: 44px;
+		line-height: 1;
+		color: var(--cream);
+	}
+
+	.hero-xp-goal {
+		color: var(--cream-dim);
+		font-size: 22px;
+	}
+
+	.hero-sub {
+		font-size: 13px;
+		color: var(--cream-dim);
+		margin-top: 4px;
+	}
+
+	.section {
+		margin-top: 28px;
+	}
+
+	.section-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		margin-bottom: 12px;
+	}
+
+	.hand-card {
+		display: block;
+		width: 100%;
+		border-radius: 22px;
+		overflow: hidden;
+		position: relative;
+		background: linear-gradient(135deg, #1a3d2e 0%, #0e2a20 100%);
+		border: 1px solid var(--hairline-strong);
+		padding: 22px;
+		height: 180px;
+		cursor: pointer;
+		text-align: left;
+		color: var(--cream);
+		font-family: inherit;
+	}
+
+	.hand-cards {
+		position: absolute;
+		right: 14px;
+		top: 18px;
+		display: flex;
+	}
+
+	.hand-title {
+		font-size: 28px;
+		line-height: 1.05;
+		margin-top: 8px;
+		max-width: 200px;
+	}
+
+	.hand-footer {
+		position: absolute;
+		bottom: 18px;
+		left: 22px;
+		right: 22px;
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	.hand-dots {
+		display: flex;
+		gap: 6px;
+	}
+
+	.mood-grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 10px;
+	}
+
+	.mood-btn {
+		border-radius: 16px;
+		padding: 14px;
+		color: var(--cream);
+		cursor: pointer;
+		text-align: left;
+		font-family: inherit;
+	}
+
+	.mood-btn:active {
+		opacity: 0.8;
+	}
+
+	.skill-tree {
+		background: rgba(245,233,212,0.04);
+		border-radius: 22px;
+		border: 1px solid var(--hairline);
+		overflow: hidden;
+	}
+
+	.skill-row {
+		display: flex;
+		align-items: center;
+		gap: 14px;
+		padding: 14px 18px;
+	}
+
+	.skill-bar {
+		width: 8px;
+		height: 40px;
+		border-radius: 4px;
+	}
+
+	.skill-info {
+		flex: 1;
+	}
+
+	.skill-progress-track {
+		width: 50px;
+		height: 4px;
+		border-radius: 2px;
+		background: rgba(245,233,212,0.1);
+		overflow: hidden;
+	}
+
+	.skill-progress-fill {
+		height: 100%;
+	}
+</style>

--- a/tilt-app/src/routes/lesson/+page.svelte
+++ b/tilt-app/src/routes/lesson/+page.svelte
@@ -1,0 +1,480 @@
+<script lang="ts">
+import { goto } from '$app/navigation';
+import TopBar from '$lib/components/TopBar.svelte';
+import PlayingCard from '$lib/components/PlayingCard.svelte';
+import Chip from '$lib/components/Chip.svelte';
+import Pill from '$lib/components/Pill.svelte';
+
+type Phase = 'setup' | 'read' | 'decide' | 'reveal';
+type Choice = 'fold' | 'call' | 'raise' | null;
+
+let phase = $state<Phase>('setup');
+let confidence = $state(60);
+let choice = $state<Choice>(null);
+let tellMeter = $state(0);
+let handNumber = $state(3);
+let totalHands = 5;
+let xpEarned = $state(0);
+
+const correct = $derived(choice === 'raise');
+
+const phaseText = $derived.by(() => {
+	switch (phase) {
+		case 'setup': return 'Folded to you on the button.';
+		case 'read': return 'Villain just min-raised. Quickly.';
+		case 'decide': return "What's your move?";
+		case 'reveal': return correct ? 'Nice read.' : 'Hmm. Re-deal that one.';
+	}
+});
+
+const xpResult = $derived.by(() => {
+	if (phase !== 'reveal' || !choice) return 0;
+	if (correct) return Math.round(20 * confidence / 60);
+	return -Math.round(5 * confidence / 60);
+});
+
+$effect(() => {
+	if (phase !== 'read') return;
+	let v = 0;
+	const id = setInterval(() => {
+		v = Math.min(100, v + 4);
+		tellMeter = v;
+		if (v >= 100) clearInterval(id);
+	}, 60);
+	return () => clearInterval(id);
+});
+
+$effect(() => {
+	if (phase === 'setup') {
+		const t = setTimeout(() => { phase = 'read'; }, 1400);
+		return () => clearTimeout(t);
+	}
+});
+
+function choose(c: Choice) {
+	choice = c;
+	phase = 'reveal';
+	xpEarned += xpResult;
+}
+
+function nextHand() {
+	if (handNumber >= totalHands) {
+		goto('/home');
+		return;
+	}
+	handNumber += 1;
+	phase = 'setup';
+	choice = null;
+	tellMeter = 0;
+	confidence = 60;
+}
+</script>
+
+<div class="screen felt-bg">
+	<TopBar onBack={() => goto('/home')}>
+		{#snippet center()}
+			Hand {handNumber} of {totalHands}
+		{/snippet}
+		{#snippet right()}
+			<Pill><span style="color: var(--gold);">●</span> +{xpEarned} XP</Pill>
+		{/snippet}
+	</TopBar>
+
+	<div class="scenario">
+		<div class="eyebrow" style="color: var(--gold);">UTG · 100BB · $1/$2 NLHE</div>
+		<div class="serif scenario-text">
+			{phaseText}
+		</div>
+	</div>
+
+	<div class="table-felt">
+		<div class="opponent-zone">
+			<div class="opponent-avatar">🎩</div>
+			<div class="mono opponent-label">Villain · UTG</div>
+			{#if phase === 'read' || phase === 'decide'}
+				<div class="tell-meter">
+					<span style="font-size: 10px;">👁</span>
+					<div class="tell-track">
+						<div class="tell-fill" style="width: {tellMeter}%;"></div>
+					</div>
+					<span class="mono tell-label">TELL</span>
+				</div>
+			{/if}
+		</div>
+
+		<div class="opponent-cards">
+			<PlayingCard faceDown size="sm" treatment="classic" />
+			<PlayingCard faceDown size="sm" treatment="classic" delay={80} />
+		</div>
+
+		<div class="pot-zone">
+			<div class="eyebrow">Pot</div>
+			<div class="mono pot-amount">$7</div>
+			<div class="pot-chips">
+				<Chip label="$1" class="chip-sm" />
+				<Chip label="$2" class="chip-sm" />
+			</div>
+		</div>
+
+		<div class="hero-cards">
+			<PlayingCard rank="A" suit="♠" size="lg" treatment="classic" />
+			<PlayingCard rank="K" suit="♠" size="lg" treatment="classic" delay={120} />
+		</div>
+	</div>
+
+	<div class="decision-panel">
+		{#if phase === 'read'}
+			<div class="anim-float read-panel">
+				<div class="eyebrow">Reading...</div>
+				<div class="read-hint">
+					Quick min-raise after a long pause = uncertainty.<br />
+					Often a hand he wishes was bigger.
+				</div>
+				<button class="btn btn-primary" style="width: 100%; margin-top: 14px;" onclick={() => { phase = 'decide'; }}>
+					Got it →
+				</button>
+			</div>
+		{/if}
+
+		{#if phase === 'decide'}
+			<div class="anim-float">
+				<div class="confidence-section">
+					<div class="confidence-header">
+						<span class="eyebrow">Confidence</span>
+						<span class="mono confidence-value">{confidence}%</span>
+					</div>
+					<input
+						type="range"
+						min="20"
+						max="100"
+						bind:value={confidence}
+						class="confidence-slider"
+					/>
+					<div class="confidence-hint">
+						Right + bold = bigger XP. Wrong + bold = bigger lesson.
+					</div>
+				</div>
+
+				<div class="action-grid">
+					<button class="action-btn action-fold" onclick={() => choose('fold')}>
+						<div class="action-icon">🗑️</div>
+						<div class="action-label">Fold</div>
+					</button>
+					<button class="action-btn action-call" onclick={() => choose('call')}>
+						<div class="action-icon">➡️</div>
+						<div class="action-label">Call $4</div>
+					</button>
+					<button class="action-btn action-raise" onclick={() => choose('raise')}>
+						<div class="action-icon">🔥</div>
+						<div class="action-label">3-bet $14</div>
+					</button>
+				</div>
+			</div>
+		{/if}
+
+		{#if phase === 'reveal'}
+			<div class="anim-float reveal-panel" class:reveal-correct={correct} class:reveal-wrong={!correct}>
+				<div class="reveal-header">
+					<div class="eyebrow reveal-verdict">
+						{correct ? '✓ Correct' : '✗ Not quite'}
+					</div>
+					<div class="mono reveal-xp">
+						{correct ? `+${xpResult}` : xpResult} XP
+					</div>
+				</div>
+				<div class="reveal-explanation">
+					AKs vs an UTG min-raiser is a <em class="serif" style="color: var(--coral-soft);">premium 3-bet</em>.
+					You either fold out his marginal stuff or build a pot you'll often win.
+				</div>
+				<button class="btn btn-cream" style="width: 100%; margin-top: 14px;" onclick={nextHand}>
+					{handNumber >= totalHands ? 'Finish session' : 'Next hand →'}
+				</button>
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.screen {
+		display: flex;
+		flex-direction: column;
+		min-height: 100vh;
+		background: var(--felt);
+	}
+
+	.scenario {
+		padding: 4px 24px 0;
+	}
+
+	.scenario-text {
+		font-size: 26px;
+		line-height: 1.1;
+		margin-top: 6px;
+	}
+
+	.table-felt {
+		flex: 1;
+		position: relative;
+		margin: 20px 16px 0;
+		border-radius: 32px;
+		background: radial-gradient(ellipse at center, var(--felt-3) 0%, var(--felt) 70%);
+		border: 1px solid var(--hairline-strong);
+		box-shadow: inset 0 0 60px rgba(0,0,0,0.4);
+		overflow: hidden;
+	}
+
+	.opponent-zone {
+		position: absolute;
+		top: 24px;
+		left: 0;
+		right: 0;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	}
+
+	.opponent-avatar {
+		width: 56px;
+		height: 56px;
+		border-radius: 999px;
+		background: #2a1a14;
+		border: 2px solid var(--hairline-strong);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 22px;
+	}
+
+	.opponent-label {
+		font-size: 11px;
+		margin-top: 6px;
+		color: var(--cream-dim);
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+	}
+
+	.tell-meter {
+		margin-top: 10px;
+		padding: 6px 12px;
+		background: rgba(0,0,0,0.5);
+		border-radius: 999px;
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		border: 1px solid rgba(255,91,72,0.3);
+	}
+
+	.tell-track {
+		width: 80px;
+		height: 4px;
+		border-radius: 2px;
+		background: rgba(245,233,212,0.15);
+		overflow: hidden;
+	}
+
+	.tell-fill {
+		height: 100%;
+		background: linear-gradient(90deg, var(--gold), var(--coral));
+		transition: width 100ms linear;
+	}
+
+	.tell-label {
+		font-size: 10px;
+		color: var(--gold);
+	}
+
+	.opponent-cards {
+		position: absolute;
+		top: 100px;
+		left: 50%;
+		transform: translateX(-50%);
+		display: flex;
+		gap: 4px;
+	}
+
+	.pot-zone {
+		position: absolute;
+		top: 46%;
+		left: 0;
+		right: 0;
+		text-align: center;
+	}
+
+	.pot-amount {
+		font-size: 22px;
+		font-weight: 700;
+		color: var(--gold);
+	}
+
+	.pot-chips {
+		display: inline-flex;
+		gap: 2px;
+		margin-top: 4px;
+	}
+
+	.chip-sm :global(.chip) {
+		width: 22px;
+		height: 22px;
+		font-size: 9px;
+	}
+
+	.hero-cards {
+		position: absolute;
+		bottom: 24px;
+		left: 50%;
+		transform: translateX(-50%);
+		display: flex;
+		gap: 6px;
+	}
+
+	.decision-panel {
+		padding: 20px 20px 28px;
+	}
+
+	.read-panel {
+		text-align: center;
+		padding: 12px;
+	}
+
+	.read-hint {
+		font-size: 14px;
+		color: var(--cream-dim);
+		margin-top: 6px;
+	}
+
+	.confidence-section {
+		padding: 0 4px 16px;
+	}
+
+	.confidence-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 8px;
+	}
+
+	.confidence-value {
+		font-size: 12px;
+		font-weight: 700;
+		color: var(--coral);
+	}
+
+	.confidence-slider {
+		width: 100%;
+		accent-color: var(--coral);
+	}
+
+	.confidence-hint {
+		font-size: 11px;
+		color: var(--cream-dim);
+		text-align: center;
+		margin-top: 4px;
+	}
+
+	.action-grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr 1fr;
+		gap: 8px;
+	}
+
+	.action-btn {
+		border-radius: 14px;
+		padding: 14px 8px;
+		cursor: pointer;
+		font-family: inherit;
+		border: 1.5px solid var(--hairline-strong);
+	}
+
+	.action-btn:active {
+		opacity: 0.85;
+		transform: translateY(1px);
+	}
+
+	.action-fold {
+		background: rgba(245,233,212,0.06);
+		color: var(--cream);
+	}
+
+	.action-call {
+		background: rgba(233,185,73,0.1);
+		color: var(--gold-soft);
+		border-color: rgba(233,185,73,0.4);
+	}
+
+	.action-raise {
+		background: var(--coral);
+		color: #2a0a05;
+		border-color: var(--coral);
+		box-shadow: 0 4px 0 #b03d30;
+	}
+
+	.action-icon {
+		font-size: 18px;
+		margin-bottom: 4px;
+	}
+
+	.action-label {
+		font-size: 13px;
+		font-weight: 600;
+	}
+
+	.reveal-panel {
+		border-radius: 18px;
+		padding: 18px;
+	}
+
+	.reveal-correct {
+		background: rgba(72,200,120,0.12);
+		border: 1px solid rgba(72,200,120,0.4);
+	}
+
+	.reveal-wrong {
+		background: rgba(255,91,72,0.12);
+		border: 1px solid rgba(255,91,72,0.4);
+	}
+
+	.reveal-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		margin-bottom: 8px;
+	}
+
+	.reveal-verdict {
+		color: #7adb9c;
+	}
+
+	.reveal-wrong .reveal-verdict {
+		color: var(--coral-soft);
+	}
+
+	.reveal-xp {
+		font-size: 14px;
+		font-weight: 700;
+		color: #7adb9c;
+	}
+
+	.reveal-wrong .reveal-xp {
+		color: var(--coral-soft);
+	}
+
+	.reveal-explanation {
+		font-size: 14px;
+		line-height: 1.4;
+	}
+
+	.anim-float {
+		animation: float-up 400ms ease both;
+	}
+
+	@keyframes float-up {
+		from {
+			opacity: 0;
+			transform: translateY(16px);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(0);
+		}
+	}
+</style>


### PR DESCRIPTION
## Summary
- Port Interactive Lesson from Design/screens/lesson.jsx to SvelteKit 2
- Core novel UX: phase state machine (setup → read → decide → reveal)
- Tell meter: animated progress bar during read phase
- Confidence slider: 20-100%, XP scaling
- 3-action decision panel with distinct styling
- Multi-hand session flow

## Changes
- **New:** `src/routes/lesson/+page.svelte` — Interactive lesson screen

## Verification
- `pnpm exec tsc --noEmit` — passes
- `pnpm build` — passes