### PR TITLE
chore: switch CI runners to self-hosted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint-and-test:
     name: Lint and Test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code
@@ -40,7 +40,7 @@ jobs:
 
   security:
     name: Security Audit
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code
@@ -66,7 +66,7 @@ jobs:
 
   code-quality:
     name: Code Quality
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code
@@ -91,7 +91,7 @@ jobs:
 
   notify:
     name: Notify
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: [lint-and-test, security, code-quality]
     if: always()
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   validate:
     name: Pre-deployment Validation
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code
@@ -43,7 +43,7 @@ jobs:
 
   create-release:
     name: Create GitHub Release
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: validate
     if: startsWith(github.ref, 'refs/tags/')
 

--- a/.github/workflows/repomix.yml
+++ b/.github/workflows/repomix.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   update-repomix:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     permissions:
       contents: write


### PR DESCRIPTION
Switch all GitHub Actions workflows from ubuntu-latest to self-hosted runner to reduce GitHub runner minute consumption.