### PR TITLE
chore: add structurelint config

### DIFF
--- a/.structurelint.yml
+++ b/.structurelint.yml
@@ -1,0 +1,58 @@
+root: true
+
+exclude:
+  - node_modules/**
+  - .git/**
+  - .svelte-kit/**
+  - dist/**
+  - build/**
+  - test-results/**
+  - playwright-report/**
+
+rules:
+  max-depth:
+    max: 5
+    exemptions:
+      - ".git/**"
+      - "node_modules/**"
+
+  max-files-in-dir:
+    max: 30
+    exemptions:
+      - ".git/**"
+      - "node_modules/**"
+
+  max-subdirs:
+    max: 15
+    exemptions:
+      - ".git/**"
+
+  naming-convention:
+    style: "kebab-case"
+    apply-to:
+      - "**/*.ts"
+      - "**/*.svelte"
+    exemptions:
+      - "**/node_modules/**"
+      - ".git/**"
+      - "README.md"
+
+  file-existence:
+    "README.md":
+      rule: "exists:1"
+      exemptions:
+        - "src/**"
+        - "e2e/**"
+        - "supabase/**"
+        - "static/**"
+        - "docs/**"
+        - "node_modules/**"
+
+  disallowed-patterns:
+    - "*.tmp"
+    - "*.bak"
+    - ".DS_Store"
+    - "*.swp"
+
+  test-adjacency:
+    enabled: false


### PR DESCRIPTION
Adds .structurelint.yml configuration for Poker SvelteKit app.\n\nRules enforced:\n- max-depth: 5\n- naming-convention: kebab-case\n- file-existence: README.md\n- disallowed-patterns: temp files\n- test-adjacency: disabled (early stage)