### PR TITLE
fix: remove extra blank line in adaptiveEngine.test.ts (biome format)

### DIFF
--- a/src/lib/core/adaptiveEngine.test.ts
+++ b/src/lib/core/adaptiveEngine.test.ts
@@ -10,7 +10,6 @@ beforeEach(() => {
 });
 
 describe('PerformanceTracker', () => {
-
 	it('initializes with empty state', () => {
 		expect(tracker.history).toHaveLength(0);
 		expect(tracker.currentStreak).toBe(0);


### PR DESCRIPTION
The deploy-pages.yml workflow failed because Biome found a stray blank line at line 13 in src/lib/core/adaptiveEngine.test.ts (between the describe and it blocks). This PR removes that extra blank line by running `biome format --write src/`, which fixes the formatting issue and allows the CI check to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor test file cleanup with no impact to product functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->