### PR TITLE
fix: add Deck-specific beforeEach to reset deck before each Deck test

### DIFF
--- a/src/lib/core/spacedRepetition.test.ts
+++ b/src/lib/core/spacedRepetition.test.ts
@@ -160,6 +160,10 @@ describe('Card', () => {
 });
 
 describe('Deck', () => {
+	beforeEach(() => {
+		deck = new Deck('Test Deck', 'A test deck');
+	});
+
 	it('initializes correctly', () => {
 		expect(deck.name).toBe('Test Deck');
 		expect(deck.description).toBe('A test deck');


### PR DESCRIPTION
## Problem

6 tests in `spacedRepetition.test.ts` were failing because the Deck describe block reused the shared `deck` variable from the top-level `beforeEach`, which pre-populates it with 5 cards.

Notable failure: line 217 expected `stats.total` to be 2 but got 7 (5 from beforeEach + 2 added in the test).

## Fix

Added a nested `beforeEach` inside the `Deck` describe block that creates a fresh empty `Deck`, overriding the shared variable. This ensures each Deck test starts with a clean slate.

## Failing tests (now passing)
- Deck > initializes correctly
- Deck > adds cards
- Deck > returns due cards
- Deck > returns new cards (never reviewed)
- Deck > getStats > returns correct stats for empty deck
- Deck > getStats > returns correct stats with cards

All 138 tests now pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test isolation by reinitializing deck state within specific test groups to ensure independent test execution and prevent state leakage between test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->