### PR TITLE
ci: switch to self-hosted runners

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   build-and-deploy:
     name: Build and Deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     environment:
       name: github-pages


### PR DESCRIPTION
Switch all workflow jobs from `ubuntu-latest` to `self-hosted` to save GitHub Actions minutes. All repos now have dedicated self-hosted macOS runners online.