### PR TITLE
feat: add telemetry abstraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI/CD Pipeline
+name: CI
 
 on:
   push:
@@ -7,8 +7,8 @@ on:
     branches: [main, develop]
 
 jobs:
-  lint-and-test:
-    name: Lint and Test
+  ci:
+    name: CI
     runs-on: self-hosted
     env:
       PUBLIC_POSTHOG_PROJECT_TOKEN: ${{ vars.PUBLIC_POSTHOG_PROJECT_TOKEN }}
@@ -32,77 +32,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run linter
+      - name: Lint
         run: pnpm run lint
 
-      - name: Run typecheck
+      - name: Typecheck
         run: pnpm run typecheck
 
-      - name: Run tests
+      - name: Test
         run: pnpm run test
-
-  security:
-    name: Security Audit
-    runs-on: self-hosted
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Run audit
-        run: pnpm audit --audit-level=moderate
-        continue-on-error: true
-
-  code-quality:
-    name: Code Quality
-    runs-on: self-hosted
-    env:
-      PUBLIC_POSTHOG_PROJECT_TOKEN: ${{ vars.PUBLIC_POSTHOG_PROJECT_TOKEN }}
-      PUBLIC_POSTHOG_HOST: ${{ vars.PUBLIC_POSTHOG_HOST }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm run build
 
-  notify:
-    name: Notify
-    runs-on: self-hosted
-    needs: [lint-and-test, security, code-quality]
-    if: always()
-
-    steps:
-      - name: Check status
-        run: |
-          echo "Pipeline status: ${{ job.status }}"
-          echo "Build completed"
+      - name: Audit
+        run: pnpm audit --audit-level=moderate
+        continue-on-error: true

--- a/.svelte-kit/ambient.d.ts
+++ b/.svelte-kit/ambient.d.ts
@@ -81,7 +81,6 @@ declare module '$env/static/private' {
 	export const OPENCODE_PROCESS_ROLE: string;
 	export const SHLVL: string;
 	export const HOME: string;
-	export const CI: string;
 	export const HOMEBREW_PREFIX: string;
 	export const FNM_DIR: string;
 	export const LOGNAME: string;
@@ -98,6 +97,13 @@ declare module '$env/static/private' {
 	export const OPENCODE: string;
 	export const COLORTERM: string;
 	export const npm_node_execpath: string;
+	export const TEST: string;
+	export const VITEST: string;
+	export const NODE_ENV: string;
+	export const PROD: string;
+	export const DEV: string;
+	export const BASE_URL: string;
+	export const MODE: string;
 }
 
 /**
@@ -134,10 +140,7 @@ declare module '$env/static/private' {
  * The above values will be the same _even if_ different values for `ENVIRONMENT` or `PUBLIC_BASE_URL` are set at runtime, as they are statically replaced in your code with their build time values.
  */
 declare module '$env/static/public' {
-	export const PUBLIC_SUPABASE_ANON_KEY: string;
-	export const PUBLIC_SUPABASE_URL: string;
-	export const PUBLIC_POSTHOG_HOST: string;
-	export const PUBLIC_POSTHOG_PROJECT_TOKEN: string;
+	
 }
 
 /**
@@ -230,7 +233,6 @@ declare module '$env/dynamic/private' {
 		OPENCODE_PROCESS_ROLE: string;
 		SHLVL: string;
 		HOME: string;
-		CI: string;
 		HOMEBREW_PREFIX: string;
 		FNM_DIR: string;
 		LOGNAME: string;
@@ -247,6 +249,13 @@ declare module '$env/dynamic/private' {
 		OPENCODE: string;
 		COLORTERM: string;
 		npm_node_execpath: string;
+		TEST: string;
+		VITEST: string;
+		NODE_ENV: string;
+		PROD: string;
+		DEV: string;
+		BASE_URL: string;
+		MODE: string;
 		[key: `PUBLIC_${string}`]: undefined;
 		[key: `${string}`]: string | undefined;
 	}
@@ -302,10 +311,6 @@ declare module '$env/dynamic/private' {
  */
 declare module '$env/dynamic/public' {
 	export const env: {
-		PUBLIC_SUPABASE_ANON_KEY: string;
-		PUBLIC_SUPABASE_URL: string;
-		PUBLIC_POSTHOG_HOST: string;
-		PUBLIC_POSTHOG_PROJECT_TOKEN: string;
 		[key: `PUBLIC_${string}`]: string | undefined;
 	}
 }

--- a/.svelte-kit/generated/client/app.js
+++ b/.svelte-kit/generated/client/app.js
@@ -1,3 +1,6 @@
+import * as client_hooks from '../../../src/hooks.client.ts';
+
+
 export { matchers } from './matchers.js';
 
 export const nodes = [
@@ -40,8 +43,8 @@ export const dictionary = {
 	};
 
 export const hooks = {
-	handleError: (({ error }) => { console.error(error) }),
-	
+	handleError: client_hooks.handleError || (({ error }) => { console.error(error) }),
+	init: client_hooks.init,
 	reroute: (() => {}),
 	transport: {}
 };

--- a/.svelte-kit/generated/client/nodes/1.js
+++ b/.svelte-kit/generated/client/nodes/1.js
@@ -1,1 +1,1 @@
-export { default as component } from "../../../../node_modules/.pnpm/@sveltejs+kit@2.59.0_@sveltejs+vite-plugin-svelte@7.0.0_svelte@5.55.5_vite@8.0.10_@type_72ff1850efe0a9b28484ed03a4d12607/node_modules/@sveltejs/kit/src/runtime/components/svelte-5/error.svelte";
+export { default as component } from "../../../../node_modules/.pnpm/@sveltejs+kit@2.59.0_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@7.0.0_svelte_ffcaade9fdd02ff53867e36bd9218907/node_modules/@sveltejs/kit/src/runtime/components/svelte-5/error.svelte";

--- a/.svelte-kit/generated/server/internal.js
+++ b/.svelte-kit/generated/server/internal.js
@@ -3,7 +3,7 @@ import root from '../root.js';
 import { set_building, set_prerendering } from '__sveltekit/environment';
 import { set_assets } from '$app/paths/internal/server';
 import { set_manifest, set_read_implementation } from '__sveltekit/server';
-import { set_private_env, set_public_env } from '../../../node_modules/.pnpm/@sveltejs+kit@2.59.0_@sveltejs+vite-plugin-svelte@7.0.0_svelte@5.55.5_vite@8.0.10_@type_72ff1850efe0a9b28484ed03a4d12607/node_modules/@sveltejs/kit/src/runtime/shared-server.js';
+import { set_private_env, set_public_env } from '../../../node_modules/.pnpm/@sveltejs+kit@2.59.0_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@7.0.0_svelte_ffcaade9fdd02ff53867e36bd9218907/node_modules/@sveltejs/kit/src/runtime/shared-server.js';
 
 export const options = {
 	app_template_contains_nonce: false,
@@ -25,7 +25,7 @@ export const options = {
 		app: ({ head, body, assets, nonce, env }) => "<!doctype html>\n<html lang=\"en\">\n\t<head>\n\t\t<meta charset=\"utf-8\" />\n\t\t<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />\n\t\t<meta name=\"text-scale\" content=\"scale\" />\n\t\t<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\" />\n\t\t<link rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin />\n\t\t<link\n\t\t\thref=\"https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;700&family=Geist:wght@400;500;600;700;800&display=swap\"\n\t\t\trel=\"stylesheet\"\n\t\t/>\n\t\t" + head + "\n\t</head>\n\t<body data-sveltekit-preload-data=\"hover\">\n\t\t<div style=\"display: contents\">" + body + "</div>\n\t</body>\n</html>\n",
 		error: ({ status, message }) => "<!doctype html>\n<html lang=\"en\">\n\t<head>\n\t\t<meta charset=\"utf-8\" />\n\t\t<title>" + message + "</title>\n\n\t\t<style>\n\t\t\tbody {\n\t\t\t\t--bg: white;\n\t\t\t\t--fg: #222;\n\t\t\t\t--divider: #ccc;\n\t\t\t\tbackground: var(--bg);\n\t\t\t\tcolor: var(--fg);\n\t\t\t\tfont-family:\n\t\t\t\t\tsystem-ui,\n\t\t\t\t\t-apple-system,\n\t\t\t\t\tBlinkMacSystemFont,\n\t\t\t\t\t'Segoe UI',\n\t\t\t\t\tRoboto,\n\t\t\t\t\tOxygen,\n\t\t\t\t\tUbuntu,\n\t\t\t\t\tCantarell,\n\t\t\t\t\t'Open Sans',\n\t\t\t\t\t'Helvetica Neue',\n\t\t\t\t\tsans-serif;\n\t\t\t\tdisplay: flex;\n\t\t\t\talign-items: center;\n\t\t\t\tjustify-content: center;\n\t\t\t\theight: 100vh;\n\t\t\t\tmargin: 0;\n\t\t\t}\n\n\t\t\t.error {\n\t\t\t\tdisplay: flex;\n\t\t\t\talign-items: center;\n\t\t\t\tmax-width: 32rem;\n\t\t\t\tmargin: 0 1rem;\n\t\t\t}\n\n\t\t\t.status {\n\t\t\t\tfont-weight: 200;\n\t\t\t\tfont-size: 3rem;\n\t\t\t\tline-height: 1;\n\t\t\t\tposition: relative;\n\t\t\t\ttop: -0.05rem;\n\t\t\t}\n\n\t\t\t.message {\n\t\t\t\tborder-left: 1px solid var(--divider);\n\t\t\t\tpadding: 0 0 0 1rem;\n\t\t\t\tmargin: 0 0 0 1rem;\n\t\t\t\tmin-height: 2.5rem;\n\t\t\t\tdisplay: flex;\n\t\t\t\talign-items: center;\n\t\t\t}\n\n\t\t\t.message h1 {\n\t\t\t\tfont-weight: 400;\n\t\t\t\tfont-size: 1em;\n\t\t\t\tmargin: 0;\n\t\t\t}\n\n\t\t\t@media (prefers-color-scheme: dark) {\n\t\t\t\tbody {\n\t\t\t\t\t--bg: #222;\n\t\t\t\t\t--fg: #ddd;\n\t\t\t\t\t--divider: #666;\n\t\t\t\t}\n\t\t\t}\n\t\t</style>\n\t</head>\n\t<body>\n\t\t<div class=\"error\">\n\t\t\t<span class=\"status\">" + status + "</span>\n\t\t\t<div class=\"message\">\n\t\t\t\t<h1>" + message + "</h1>\n\t\t\t</div>\n\t\t</div>\n\t</body>\n</html>\n"
 	},
-	version_hash: "t6rkup"
+	version_hash: "1yejf0e"
 };
 
 export async function get_hooks() {
@@ -34,7 +34,7 @@ export async function get_hooks() {
 	let handleError;
 	let handleValidationError;
 	let init;
-	
+	({ handle, handleFetch, handleError, handleValidationError, init } = await import("../../../src/hooks.server.ts"));
 
 	let reroute;
 	let transport;

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,7 +1,7 @@
-import { captureError } from '$lib/telemetry';
-import { PUBLIC_POSTHOG_HOST, PUBLIC_POSTHOG_PROJECT_TOKEN } from '$env/static/public';
 import type { HandleClientError } from '@sveltejs/kit';
 import posthog from 'posthog-js';
+import { PUBLIC_POSTHOG_HOST, PUBLIC_POSTHOG_PROJECT_TOKEN } from '$env/static/public';
+import { captureError } from '$lib/telemetry';
 
 export async function init() {
 	posthog.init(PUBLIC_POSTHOG_PROJECT_TOKEN, {

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,6 +1,7 @@
+import { captureError } from '$lib/telemetry';
+import { PUBLIC_POSTHOG_HOST, PUBLIC_POSTHOG_PROJECT_TOKEN } from '$env/static/public';
 import type { HandleClientError } from '@sveltejs/kit';
 import posthog from 'posthog-js';
-import { PUBLIC_POSTHOG_HOST, PUBLIC_POSTHOG_PROJECT_TOKEN } from '$env/static/public';
 
 export async function init() {
 	posthog.init(PUBLIC_POSTHOG_PROJECT_TOKEN, {
@@ -13,6 +14,6 @@ export async function init() {
 }
 
 export const handleError: HandleClientError = async ({ error, status, message }) => {
-	posthog.captureException(error);
+	captureError(error, { status, message, source: 'client' }).catch(() => {});
 	return { message, status };
 };

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,6 +1,6 @@
 import type { Handle, HandleServerError } from '@sveltejs/kit';
 import { PUBLIC_POSTHOG_HOST } from '$env/static/public';
-import { getPostHogClient } from '$lib/server/posthog';
+import { pageview, captureError, shutdown } from '$lib/telemetry';
 
 export const handle: Handle = async ({ event, resolve }) => {
 	const { pathname } = event.url;
@@ -46,24 +46,20 @@ export const handle: Handle = async ({ event, resolve }) => {
 		}
 	}
 
-	return resolve(event);
+	const response = await resolve(event);
+
+	if (!pathname.startsWith('/api') && !pathname.startsWith('/_')) {
+		pageview(pathname).catch(() => {});
+	}
+
+	return response;
 };
 
-export const handleError: HandleServerError = async ({ error, status, message, event }) => {
-	try {
-		const posthog = getPostHogClient();
-		const distinctId = (event.locals as any)?.session?.user?.id ?? 'server';
-
-		posthog.capture({
-			distinctId,
-			event: 'server_error',
-			properties: {
-				error: error instanceof Error ? error.message : String(error),
-				status,
-				message
-			}
-		});
-	} catch {}
-
+export const handleError: HandleServerError = async ({ error, status, message }) => {
+	captureError(error, { status, message, source: 'server' }).catch(() => {});
 	return { message, status };
 };
+
+process.on('SIGTERM', () => {
+	shutdown().catch(() => {});
+});

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,6 +1,6 @@
 import type { Handle, HandleServerError } from '@sveltejs/kit';
 import { PUBLIC_POSTHOG_HOST } from '$env/static/public';
-import { pageview, captureError, shutdown } from '$lib/telemetry';
+import { captureError, pageview, shutdown } from '$lib/telemetry';
 
 export const handle: Handle = async ({ event, resolve }) => {
 	const { pathname } = event.url;
@@ -60,6 +60,8 @@ export const handleError: HandleServerError = async ({ error, status, message })
 	return { message, status };
 };
 
-process.on('SIGTERM', () => {
-	shutdown().catch(() => {});
+['SIGTERM', 'SIGINT'].forEach((signal) => {
+	process.on(signal, () => {
+		shutdown().catch(() => {});
+	});
 });

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -69,7 +69,7 @@ export async function shutdown() {
 	serverPhInstance = null;
 }
 
-let clientPhInstance: import('posthog-js').default | null = null;
+let clientPhInstance: Record<string, any> | null = null;
 
 async function getClientPh() {
 	if (!browser) return null;

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,0 +1,103 @@
+import { browser } from '$app/environment';
+import { PUBLIC_POSTHOG_HOST, PUBLIC_POSTHOG_PROJECT_TOKEN } from '$env/static/public';
+
+const enabled = !!PUBLIC_POSTHOG_PROJECT_TOKEN;
+
+export async function track(event: string, props?: Record<string, unknown>) {
+	if (!enabled) return;
+	if (browser) {
+		const ph = await getClientPh();
+		ph?.capture(event, props);
+	} else {
+		const ph = await getServerPh();
+		ph?.capture({ distinctId: 'server', event, properties: props });
+	}
+}
+
+export async function pageview(route: string) {
+	if (!enabled) return;
+	if (browser) {
+		const ph = await getClientPh();
+		ph?.capture('$pageview', { $current_url: route });
+	} else {
+		const ph = await getServerPh();
+		ph?.capture({ distinctId: 'server', event: '$pageview', properties: { $current_url: route } });
+	}
+}
+
+export async function captureError(err: unknown, ctx?: Record<string, unknown>) {
+	if (!enabled) return;
+	if (browser) {
+		const ph = await getClientPh();
+		ph?.captureException(err, ctx);
+	} else {
+		const ph = await getServerPh();
+		ph?.capture({
+			distinctId: 'server',
+			event: 'server_error',
+			properties: {
+				error: err instanceof Error ? err.message : String(err),
+				...ctx
+			}
+		});
+	}
+}
+
+export async function identify(userId: string, traits?: Record<string, unknown>) {
+	if (!enabled) return;
+	if (browser) {
+		const ph = await getClientPh();
+		ph?.identify(userId, traits);
+	} else {
+		const ph = await getServerPh();
+		ph?.identify({ distinctId: userId, properties: traits });
+	}
+}
+
+export async function reset() {
+	if (!enabled || !browser) return;
+	const ph = await getClientPh();
+	ph?.reset();
+}
+
+export async function shutdown() {
+	if (!enabled || browser) return;
+	const ph = await getServerPh();
+	await ph?.shutdown();
+	serverPhInstance = null;
+}
+
+let clientPhInstance: any = null;
+
+async function getClientPh() {
+	if (!browser) return null;
+	if (clientPhInstance) return clientPhInstance;
+	const mod = await import('posthog-js');
+	clientPhInstance = mod.default;
+	if (!(clientPhInstance as any).__tilt_init) {
+		clientPhInstance.init(PUBLIC_POSTHOG_PROJECT_TOKEN, {
+			api_host: '/ingest',
+			ui_host: PUBLIC_POSTHOG_HOST,
+			defaults: '2026-01-30',
+			capture_exceptions: true,
+			person_profiles: 'identified_only'
+		});
+		(clientPhInstance as any).__tilt_init = true;
+	}
+	return clientPhInstance;
+}
+
+let serverPhInstance: any = null;
+
+async function getServerPh() {
+	if (browser) return null;
+	if (serverPhInstance) return serverPhInstance;
+	const { PostHog } = await import('posthog-node');
+	serverPhInstance = new PostHog(PUBLIC_POSTHOG_PROJECT_TOKEN, {
+		host: PUBLIC_POSTHOG_HOST,
+		flushAt: 1,
+		flushInterval: 0,
+		personProfiles: 'identified_only'
+	});
+	return serverPhInstance;
+}

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -69,7 +69,7 @@ export async function shutdown() {
 	serverPhInstance = null;
 }
 
-let clientPhInstance: ReturnType<typeof import('posthog-js')['default']> | null = null;
+let clientPhInstance: import('posthog-js').default | null = null;
 
 async function getClientPh() {
 	if (!browser) return null;
@@ -90,7 +90,7 @@ async function getClientPh() {
 	return clientPhInstance;
 }
 
-let serverPhInstance: Awaited<ReturnType<typeof import('posthog-node')['PostHog']>> | null = null;
+let serverPhInstance: import('posthog-node').PostHog | null = null;
 
 async function getServerPh() {
 	if (browser) return null;

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -10,7 +10,8 @@ export async function track(event: string, props?: Record<string, unknown>) {
 		ph?.capture(event, props);
 	} else {
 		const ph = await getServerPh();
-		ph?.capture({ distinctId: 'server', event, properties: props });
+		const distinctId = props?.userId ? String(props.userId) : 'server';
+		ph?.capture({ distinctId, event, properties: props });
 	}
 }
 
@@ -37,6 +38,7 @@ export async function captureError(err: unknown, ctx?: Record<string, unknown>) 
 			event: 'server_error',
 			properties: {
 				error: err instanceof Error ? err.message : String(err),
+				stack: err instanceof Error ? err.stack : undefined,
 				...ctx
 			}
 		});
@@ -62,32 +64,33 @@ export async function reset() {
 
 export async function shutdown() {
 	if (!enabled || browser) return;
-	const ph = await getServerPh();
-	await ph?.shutdown();
+	if (!serverPhInstance) return;
+	await serverPhInstance.shutdown();
 	serverPhInstance = null;
 }
 
-let clientPhInstance: any = null;
+let clientPhInstance: ReturnType<typeof import('posthog-js')['default']> | null = null;
 
 async function getClientPh() {
 	if (!browser) return null;
 	if (clientPhInstance) return clientPhInstance;
 	const mod = await import('posthog-js');
 	clientPhInstance = mod.default;
-	if (!(clientPhInstance as any).__tilt_init) {
+	if (!(clientPhInstance as Record<string, unknown>).__tilt_init) {
 		clientPhInstance.init(PUBLIC_POSTHOG_PROJECT_TOKEN, {
 			api_host: '/ingest',
 			ui_host: PUBLIC_POSTHOG_HOST,
 			defaults: '2026-01-30',
+			capture_pageview: false,
 			capture_exceptions: true,
 			person_profiles: 'identified_only'
 		});
-		(clientPhInstance as any).__tilt_init = true;
+		(clientPhInstance as Record<string, unknown>).__tilt_init = true;
 	}
 	return clientPhInstance;
 }
 
-let serverPhInstance: any = null;
+let serverPhInstance: Awaited<ReturnType<typeof import('posthog-node')['PostHog']>> | null = null;
 
 async function getServerPh() {
 	if (browser) return null;
@@ -95,8 +98,6 @@ async function getServerPh() {
 	const { PostHog } = await import('posthog-node');
 	serverPhInstance = new PostHog(PUBLIC_POSTHOG_PROJECT_TOKEN, {
 		host: PUBLIC_POSTHOG_HOST,
-		flushAt: 1,
-		flushInterval: 0,
 		personProfiles: 'identified_only'
 	});
 	return serverPhInstance;


### PR DESCRIPTION
Closes #232. Single telemetry abstraction at src/lib/telemetry.ts — PostHog-backed with no-op fallback. Hooks into SvelteKit handle + handleError. Lazy-loads client/server SDKs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Implemented telemetry infrastructure for event and pageview tracking across the application
* Enhanced error reporting with unified error capture across client and server environments
* Added graceful shutdown handling to ensure proper resource cleanup when the application terminates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->