### PR TITLE
feat(ai): env-driven AI provider switching with Ollama sidecar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,22 @@
 VITE_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 VITE_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+
+# AI Provider (ollama | openrouter | groq | mini)
+# mini = Ollama sidecar in Docker (production)
+VITE_AI_PROVIDER=ollama
+
+# Local AI (ollama)
+VITE_LOCAL_AI_BASE_URL=http://localhost:11434/v1
+VITE_LOCAL_AI_MODEL=llama3.2
+
+# Production AI (mini / openrouter / groq)
+VITE_PROD_AI_BASE_URL=http://localhost:11434/v1
+VITE_PROD_AI_MODEL=qwen2.5:0.5b
+
+# OpenRouter (set VITE_AI_PROVIDER=openrouter)
+VITE_OPENROUTER_API_KEY=
+VITE_OPENROUTER_MODEL=openai/gpt-4o-mini
+
+# Groq (set VITE_AI_PROVIDER=groq)
+VITE_GROQ_API_KEY=
+VITE_GROQ_MODEL=llama-3.3-70b-versatile

--- a/.env.example
+++ b/.env.example
@@ -1,22 +1,21 @@
-VITE_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-VITE_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 
-# AI Provider (ollama | openrouter | groq | mini)
+# AI Provider (ollama | mini | openrouter | groq)
 # mini = Ollama sidecar in Docker (production)
-VITE_AI_PROVIDER=ollama
+AI_PROVIDER=ollama
 
-# Local AI (ollama)
-VITE_LOCAL_AI_BASE_URL=http://localhost:11434/v1
-VITE_LOCAL_AI_MODEL=llama3.2
+# Local AI (ollama / mini)
+LOCAL_AI_BASE_URL=http://localhost:11434/v1
+OLLAMA_MODEL=llama3.2
 
-# Production AI (mini / openrouter / groq)
-VITE_PROD_AI_BASE_URL=http://localhost:11434/v1
-VITE_PROD_AI_MODEL=qwen2.5:0.5b
+# Mini model (Docker sidecar)
+MINI_MODEL=qwen2.5:0.5b
 
-# OpenRouter (set VITE_AI_PROVIDER=openrouter)
-VITE_OPENROUTER_API_KEY=
-VITE_OPENROUTER_MODEL=openai/gpt-4o-mini
+# OpenRouter (set AI_PROVIDER=openrouter)
+OPENROUTER_API_KEY=
+OPENROUTER_MODEL=openai/gpt-4o-mini
 
-# Groq (set VITE_AI_PROVIDER=groq)
-VITE_GROQ_API_KEY=
-VITE_GROQ_MODEL=llama-3.3-70b-versatile
+# Groq (set AI_PROVIDER=groq)
+GROQ_API_KEY=
+GROQ_MODEL=llama-3.1-8b-instant

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,0 +1,57 @@
+name: PR Agent
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: pr-agent-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  pr-agent:
+    runs-on: self-hosted
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run PR Agent
+        env:
+          GITHUB.USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI.KEY: lm-studio
+          OPENAI.API_BASE: http://localhost:1234/v1
+          OPENAI.API_TYPE: "openai"
+          CONFIG.MODEL: "openai/qwen3.6-35b-a3b-ud-mlx"
+          CONFIG.FALLBACK_MODELS: '[]'
+          CONFIG.CUSTOM_MODEL_MAX_TOKENS: "32768"
+          CONFIG.AI_TIMEOUT: "300"
+          GITHUB_ACTION_CONFIG.AUTO_REVIEW: "true"
+          GITHUB_ACTION_CONFIG.AUTO_DESCRIBE: "true"
+          GITHUB_ACTION_CONFIG.AUTO_IMPROVE: "false"
+          GITHUB_ACTION_CONFIG.PR_ACTIONS: '["opened", "reopened", "ready_for_review"]'
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          if ! command -v pr-agent &>/dev/null; then
+            echo "ERROR: pr-agent not installed globally. Run: uv tool install pr-agent --with tiktoken --python 3.12"
+            exit 1
+          fi
+
+          PR_URL="https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.issue.number }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            pr-agent --pr_url="$PR_URL" review
+          elif echo "$COMMENT_BODY" | grep -q "^/review"; then
+            pr-agent --pr_url="$PR_URL" review
+          elif echo "$COMMENT_BODY" | grep -q "^/describe"; then
+            pr-agent --pr_url="$PR_URL" describe
+          elif echo "$COMMENT_BODY" | grep -q "^/improve"; then
+            pr-agent --pr_url="$PR_URL" improve
+          elif echo "$COMMENT_BODY" | grep -q "^/ask"; then
+            QUESTION="${COMMENT_BODY#/ask }"
+            pr-agent --pr_url="$PR_URL" ask "$QUESTION"
+          fi

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -12,6 +12,13 @@ concurrency:
 
 jobs:
   pr-agent:
+    if: >
+      github.event_name == 'pull_request' ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      )
     runs-on: self-hosted
     permissions:
       contents: read
@@ -45,13 +52,18 @@ jobs:
           PR_URL="https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.issue.number }}"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             pr-agent --pr_url="$PR_URL" review
-          elif echo "$COMMENT_BODY" | grep -q "^/review"; then
+          elif echo "$COMMENT_BODY" | grep -qE '^/review([[:space:]]|$)'; then
             pr-agent --pr_url="$PR_URL" review
-          elif echo "$COMMENT_BODY" | grep -q "^/describe"; then
+          elif echo "$COMMENT_BODY" | grep -qE '^/describe([[:space:]]|$)'; then
             pr-agent --pr_url="$PR_URL" describe
-          elif echo "$COMMENT_BODY" | grep -q "^/improve"; then
+          elif echo "$COMMENT_BODY" | grep -qE '^/improve([[:space:]]|$)'; then
             pr-agent --pr_url="$PR_URL" improve
-          elif echo "$COMMENT_BODY" | grep -q "^/ask"; then
-            QUESTION="${COMMENT_BODY#/ask }"
+          elif echo "$COMMENT_BODY" | grep -qE '^/ask([[:space:]].+)?$'; then
+            QUESTION="${COMMENT_BODY#/ask}"
+            QUESTION="${QUESTION# }"
+            if [ -z "$QUESTION" ]; then
+              echo "Usage: /ask <question>"
+              exit 1
+            fi
             pr-agent --pr_url="$PR_URL" ask "$QUESTION"
           fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,15 +6,15 @@ services:
     ports:
       - '${PORT:-3000}:80'
     environment:
-      - VITE_AI_PROVIDER=${VITE_AI_PROVIDER:-mini}
-      - VITE_PROD_AI_BASE_URL=http://ollama:11434/v1
-      - VITE_PROD_AI_MODEL=${VITE_PROD_AI_MODEL:-qwen2.5:0.5b}
-      - VITE_PUBLIC_SUPABASE_URL=${VITE_PUBLIC_SUPABASE_URL}
-      - VITE_PUBLIC_SUPABASE_ANON_KEY=${VITE_PUBLIC_SUPABASE_ANON_KEY}
-      - VITE_OPENROUTER_API_KEY=${VITE_OPENROUTER_API_KEY:-}
-      - VITE_OPENROUTER_MODEL=${VITE_OPENROUTER_MODEL:-}
-      - VITE_GROQ_API_KEY=${VITE_GROQ_API_KEY:-}
-      - VITE_GROQ_MODEL=${VITE_GROQ_MODEL:-}
+      - AI_PROVIDER=${AI_PROVIDER:-mini}
+      - LOCAL_AI_BASE_URL=http://ollama:11434/v1
+      - MINI_MODEL=${MINI_MODEL:-qwen2.5:0.5b}
+      - PUBLIC_SUPABASE_URL=${PUBLIC_SUPABASE_URL}
+      - PUBLIC_SUPABASE_ANON_KEY=${PUBLIC_SUPABASE_ANON_KEY}
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - OPENROUTER_MODEL=${OPENROUTER_MODEL:-}
+      - GROQ_API_KEY=${GROQ_API_KEY:-}
+      - GROQ_MODEL=${GROQ_MODEL:-}
     depends_on:
       - ollama
     restart: unless-stopped
@@ -24,7 +24,7 @@ services:
     volumes:
       - ollama_data:/root/.ollama
     ports:
-      - '11434:11434'
+      - '127.0.0.1:11434:11434'
     restart: unless-stopped
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - '${PORT:-3000}:80'
+    environment:
+      - VITE_AI_PROVIDER=${VITE_AI_PROVIDER:-mini}
+      - VITE_PROD_AI_BASE_URL=http://ollama:11434/v1
+      - VITE_PROD_AI_MODEL=${VITE_PROD_AI_MODEL:-qwen2.5:0.5b}
+      - VITE_PUBLIC_SUPABASE_URL=${VITE_PUBLIC_SUPABASE_URL}
+      - VITE_PUBLIC_SUPABASE_ANON_KEY=${VITE_PUBLIC_SUPABASE_ANON_KEY}
+      - VITE_OPENROUTER_API_KEY=${VITE_OPENROUTER_API_KEY:-}
+      - VITE_OPENROUTER_MODEL=${VITE_OPENROUTER_MODEL:-}
+      - VITE_GROQ_API_KEY=${VITE_GROQ_API_KEY:-}
+      - VITE_GROQ_MODEL=${VITE_GROQ_MODEL:-}
+    depends_on:
+      - ollama
+    restart: unless-stopped
+
+  ollama:
+    image: ollama/ollama
+    volumes:
+      - ollama_data:/root/.ollama
+    ports:
+      - '11434:11434'
+    restart: unless-stopped
+
+volumes:
+  ollama_data:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+packages: []
+
 allowBuilds:
   core-js: true
   protobufjs: true

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,4 +1,6 @@
-type AIProvider = 'ollama' | 'openrouter' | 'groq' | 'mini';
+import { env } from '$env/dynamic/private';
+
+type AIProvider = 'ollama' | 'mini' | 'openrouter' | 'groq';
 
 interface AIMessage {
 	role: 'system' | 'user' | 'assistant';
@@ -16,28 +18,54 @@ export interface HandInfo {
 	tableSize?: string;
 }
 
+interface ChatCompletionResponse {
+	choices?: {
+		message?: {
+			content?: string;
+		};
+	}[];
+}
+
+const VALID_PROVIDERS: AIProvider[] = ['ollama', 'mini', 'openrouter', 'groq'];
+const AI_REQUEST_TIMEOUT_MS = 30000;
+
 function getProvider(): AIProvider {
-	return (import.meta.env.VITE_AI_PROVIDER as AIProvider) || 'ollama';
+	const provider = (env.AI_PROVIDER || 'ollama') as AIProvider;
+	if (!VALID_PROVIDERS.includes(provider)) {
+		console.warn(`Invalid AI_PROVIDER "${env.AI_PROVIDER}", falling back to "ollama"`);
+		return 'ollama';
+	}
+	return provider;
 }
 
 function getBaseUrl(): string {
 	const provider = getProvider();
-	if (provider === 'ollama') {
-		return import.meta.env.VITE_LOCAL_AI_BASE_URL || 'http://localhost:11434/v1';
+	switch (provider) {
+		case 'ollama':
+		case 'mini':
+			return env.LOCAL_AI_BASE_URL || 'http://localhost:11434/v1';
+		case 'openrouter':
+			return 'https://openrouter.ai/api/v1';
+		case 'groq':
+			return 'https://api.groq.com/openai/v1';
+		default:
+			return env.LOCAL_AI_BASE_URL || 'http://localhost:11434/v1';
 	}
-	return import.meta.env.VITE_PROD_AI_BASE_URL || 'http://localhost:11434/v1';
 }
 
 function getModel(): string {
-	switch (getProvider()) {
+	const provider = getProvider();
+	switch (provider) {
 		case 'ollama':
-			return import.meta.env.VITE_LOCAL_AI_MODEL || 'llama3.2';
+			return env.OLLAMA_MODEL || 'llama3.2';
 		case 'mini':
-			return import.meta.env.VITE_PROD_AI_MODEL || 'qwen2.5:0.5b';
+			return env.MINI_MODEL || 'phi3:mini';
 		case 'openrouter':
-			return import.meta.env.VITE_OPENROUTER_MODEL || 'openai/gpt-4o-mini';
+			return env.OPENROUTER_MODEL || 'openai/gpt-4o-mini';
 		case 'groq':
-			return import.meta.env.VITE_GROQ_MODEL || 'llama-3.3-70b-versatile';
+			return env.GROQ_MODEL || 'llama-3.1-8b-instant';
+		default:
+			return 'llama3.2';
 	}
 }
 
@@ -45,13 +73,13 @@ function getAuthHeaders(): Record<string, string> {
 	const provider = getProvider();
 	if (provider === 'openrouter') {
 		return {
-			Authorization: `Bearer ${import.meta.env.VITE_OPENROUTER_API_KEY || ''}`,
-			'HTTP-Referer': typeof window !== 'undefined' ? window.location.origin : ''
+			Authorization: `Bearer ${env.OPENROUTER_API_KEY || ''}`,
+			'HTTP-Referer': ''
 		};
 	}
 	if (provider === 'groq') {
 		return {
-			Authorization: `Bearer ${import.meta.env.VITE_GROQ_API_KEY || ''}`
+			Authorization: `Bearer ${env.GROQ_API_KEY || ''}`
 		};
 	}
 	return {};
@@ -60,27 +88,43 @@ function getAuthHeaders(): Record<string, string> {
 async function callAI(messages: AIMessage[]): Promise<string> {
 	const baseUrl = getBaseUrl();
 	const model = getModel();
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), AI_REQUEST_TIMEOUT_MS);
 
-	const res = await fetch(`${baseUrl}/chat/completions`, {
-		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json',
-			...getAuthHeaders()
-		},
-		body: JSON.stringify({
-			model,
-			messages,
-			temperature: 0.7
-		})
-	});
+	try {
+		const res = await fetch(`${baseUrl}/chat/completions`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				...getAuthHeaders()
+			},
+			body: JSON.stringify({
+				model,
+				messages,
+				temperature: 0.7
+			}),
+			signal: controller.signal
+		});
 
-	if (!res.ok) {
-		const text = await res.text();
-		throw new Error(`AI chat failed: ${res.status} ${text}`);
+		if (!res.ok) {
+			const text = await res.text();
+			throw new Error(`AI chat failed: ${res.status} ${text}`);
+		}
+
+		const data: ChatCompletionResponse = await res.json();
+		const content = data.choices?.[0]?.message?.content;
+		if (typeof content !== 'string') {
+			throw new Error('Invalid AI response: missing message content');
+		}
+		return content;
+	} catch (error) {
+		if (error instanceof Error && error.name === 'AbortError') {
+			throw new Error('AI request timed out after 30 seconds');
+		}
+		throw error;
+	} finally {
+		clearTimeout(timeoutId);
 	}
-
-	const data = await res.json();
-	return data.choices?.[0]?.message?.content || '';
 }
 
 export async function generate(prompt: string): Promise<string> {

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,0 +1,120 @@
+type AIProvider = 'ollama' | 'openrouter' | 'groq' | 'mini';
+
+interface AIMessage {
+	role: 'system' | 'user' | 'assistant';
+	content: string;
+}
+
+export interface HandInfo {
+	holeCards: string;
+	position: string;
+	stackSize: string;
+	action?: string;
+	board?: string;
+	opponentAction?: string;
+	gameType?: 'cash' | 'mtt' | 'sng';
+	tableSize?: string;
+}
+
+function getProvider(): AIProvider {
+	return (import.meta.env.VITE_AI_PROVIDER as AIProvider) || 'ollama';
+}
+
+function getBaseUrl(): string {
+	const provider = getProvider();
+	if (provider === 'ollama') {
+		return import.meta.env.VITE_LOCAL_AI_BASE_URL || 'http://localhost:11434/v1';
+	}
+	return import.meta.env.VITE_PROD_AI_BASE_URL || 'http://localhost:11434/v1';
+}
+
+function getModel(): string {
+	switch (getProvider()) {
+		case 'ollama':
+			return import.meta.env.VITE_LOCAL_AI_MODEL || 'llama3.2';
+		case 'mini':
+			return import.meta.env.VITE_PROD_AI_MODEL || 'qwen2.5:0.5b';
+		case 'openrouter':
+			return import.meta.env.VITE_OPENROUTER_MODEL || 'openai/gpt-4o-mini';
+		case 'groq':
+			return import.meta.env.VITE_GROQ_MODEL || 'llama-3.3-70b-versatile';
+	}
+}
+
+function getAuthHeaders(): Record<string, string> {
+	const provider = getProvider();
+	if (provider === 'openrouter') {
+		return {
+			Authorization: `Bearer ${import.meta.env.VITE_OPENROUTER_API_KEY || ''}`,
+			'HTTP-Referer': typeof window !== 'undefined' ? window.location.origin : ''
+		};
+	}
+	if (provider === 'groq') {
+		return {
+			Authorization: `Bearer ${import.meta.env.VITE_GROQ_API_KEY || ''}`
+		};
+	}
+	return {};
+}
+
+async function callAI(messages: AIMessage[]): Promise<string> {
+	const baseUrl = getBaseUrl();
+	const model = getModel();
+
+	const res = await fetch(`${baseUrl}/chat/completions`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			...getAuthHeaders()
+		},
+		body: JSON.stringify({
+			model,
+			messages,
+			temperature: 0.7
+		})
+	});
+
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(`AI chat failed: ${res.status} ${text}`);
+	}
+
+	const data = await res.json();
+	return data.choices?.[0]?.message?.content || '';
+}
+
+export async function generate(prompt: string): Promise<string> {
+	return chat([{ role: 'user', content: prompt }]);
+}
+
+export async function chat(messages: AIMessage[]): Promise<string> {
+	return callAI(messages);
+}
+
+export async function analyzeHand(hand: HandInfo): Promise<string> {
+	const prompt = buildHandAnalysisPrompt(hand);
+	return generate(prompt);
+}
+
+function buildHandAnalysisPrompt(hand: HandInfo): string {
+	const parts: string[] = [
+		'You are an expert poker coach. Analyze this hand and provide strategic advice.',
+		'',
+		`Game: ${hand.gameType || 'NLHE'}`,
+		`Hole cards: ${hand.holeCards}`,
+		`Position: ${hand.position}`,
+		`Stack: ${hand.stackSize}`,
+		`Table: ${hand.tableSize || '6-max'}`
+	];
+
+	if (hand.action) parts.push(`Action so far: ${hand.action}`);
+	if (hand.board) parts.push(`Board: ${hand.board}`);
+	if (hand.opponentAction) parts.push(`Opponent: ${hand.opponentAction}`);
+
+	parts.push('');
+	parts.push(
+		'Give: 1) Recommended action, 2) Reasoning based on ranges/position/stack depth, 3) Key concept to apply. Keep it concise (2-3 sentences).'
+	);
+
+	return parts.join('\n');
+}


### PR DESCRIPTION
## Summary
- Add `src/lib/ai.ts` with env-driven `AI_PROVIDER` switching (ollama/mini/openrouter/groq), including `analyzeHand()` for poker AI
- Add `docker-compose.yml` with app + Ollama sidecar
- Add `.env.example` with AI_PROVIDER and model configuration vars
- Add `.github/workflows/pr-agent.yml` for self-hosted PR-Agent via LM Studio

## AI Provider Strategy
Single `AI_PROVIDER` env var switches backend. Code never changes — only `.env` does:
- `AI_PROVIDER=mini` — CPU-friendly models via Ollama sidecar on Droplet
- `AI_PROVIDER=openrouter` — OpenRouter API
- `AI_PROVIDER=groq` — Groq API
- `AI_PROVIDER=ollama` — localhost dev only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AI-powered poker hand analysis supporting multiple providers (Ollama, OpenRouter, Groq).
  * Added Docker Compose support for simplified local deployment with integrated local AI option.
  
* **Chores**
  * Added environment configuration templates for AI providers and Supabase setup.
  * Added GitHub Actions workflow for automated pull request review and analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->