### PR TITLE
fix: shared Ollama + pnpm allowBuilds for Coolify deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --ignore-scripts=false
 
 COPY . .
 RUN pnpm run build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - '${PORT:-3000}:80'
     environment:
       - AI_PROVIDER=${AI_PROVIDER:-mini}
-      - LOCAL_AI_BASE_URL=http://ollama:11434/v1
+      - LOCAL_AI_BASE_URL=http://ollama-shared:11434/v1
       - MINI_MODEL=${MINI_MODEL:-qwen2.5:0.5b}
       - PUBLIC_SUPABASE_URL=${PUBLIC_SUPABASE_URL}
       - PUBLIC_SUPABASE_ANON_KEY=${PUBLIC_SUPABASE_ANON_KEY}
@@ -15,17 +15,10 @@ services:
       - OPENROUTER_MODEL=${OPENROUTER_MODEL:-}
       - GROQ_API_KEY=${GROQ_API_KEY:-}
       - GROQ_MODEL=${GROQ_MODEL:-}
-    depends_on:
-      - ollama
     restart: unless-stopped
+    networks:
+      - coolify
 
-  ollama:
-    image: ollama/ollama
-    volumes:
-      - ollama_data:/root/.ollama
-    ports:
-      - '127.0.0.1:11434:11434'
-    restart: unless-stopped
-
-volumes:
-  ollama_data:
+networks:
+  coolify:
+    external: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ packages: []
 allowBuilds:
   core-js: true
   protobufjs: true
+  esbuild: true


### PR DESCRIPTION
## Summary
- Remove per-app Ollama sidecar from docker-compose.yml, add Docker `coolify` external network
- Change `LOCAL_AI_BASE_URL` from `http://ollama:11434/v1` to `http://ollama-shared:11434/v1`
- Add `esbuild: true` to `allowBuilds` in pnpm-workspace.yaml
- Add `--ignore-scripts=false` to Dockerfile pnpm install for native binary downloads

Supersedes #256 (conflicting branch). Vidiom/Songster/ObstetraScroll already have these changes on main/master.