### PR TITLE
fix: add Traefik labels for sslip.io routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,11 @@ services:
       - GROQ_MODEL=${GROQ_MODEL:-}
       - PUBLIC_POSTHOG_HOST=${PUBLIC_POSTHOG_HOST:-https://us.posthog.com}
       - PUBLIC_POSTHOG_PROJECT_TOKEN=${PUBLIC_POSTHOG_PROJECT_TOKEN:-}
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.tilt.rule=Host(`tilt.159.223.26.67.sslip.io`)
+      - traefik.http.routers.tilt.entrypoints=http
+      - traefik.http.services.tilt.loadbalancer.server.port=80
     restart: unless-stopped
     networks:
       - coolify


### PR DESCRIPTION
Add Traefik routing labels for tilt.159.223.26.67.sslip.io

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service configuration with routing and load balancing capabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jonathangadeaharder/Tilt/pull/259)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->