### PR TITLE
fix: add Docker HEALTHCHECK for container health monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,13 @@ COPY . .
 RUN pnpm run build
 
 FROM nginx:alpine AS runner
+RUN apk add --no-cache curl
 COPY --from=builder /app/build /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:80/ || exit 1
+
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- Add `HEALTHCHECK` instruction to Dockerfile (nginx:alpine runner)
- Install `curl` in alpine for health check probe
- Check `http://localhost:80/` every 30s, 5s timeout, 3 retries

## Why
Docker health checks enable Coolify and UptimeRobot to detect container failures automatically. Tilt was one of 3 apps missing a HEALTHCHECK in its Dockerfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment reliability with automated health monitoring to detect and respond to service interruptions more efficiently.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jonathangadeaharder/Tilt/pull/260)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->