### PR TITLE
fix: add ORIGIN env var for CSRF protection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,9 @@ services:
       - OPENROUTER_MODEL=${OPENROUTER_MODEL:-}
       - GROQ_API_KEY=${GROQ_API_KEY:-}
       - GROQ_MODEL=${GROQ_MODEL:-}
-      - PUBLIC_POSTHOG_HOST=${PUBLIC_POSTHOG_HOST:-https://us.posthog.com}
+      - PUBLIC_POSTHOG_HOST=${PUBLIC_POSTHOG_HOST:-https://eu.i.posthog.com}
       - PUBLIC_POSTHOG_PROJECT_TOKEN=${PUBLIC_POSTHOG_PROJECT_TOKEN:-}
+      - ORIGIN=${ORIGIN:-http://localhost:3000}
     labels:
       - traefik.enable=true
       - traefik.http.routers.tilt.rule=Host(`tilt.159.223.26.67.sslip.io`)


### PR DESCRIPTION
## Summary
- Add ORIGIN env var to docker-compose.yml
- Required for SvelteKit CSRF form submission validation
- Without it, SvelteKit defaults to localhost which doesn't match sslip.io origin
- Also fix PostHog host default to EU region