### PR TITLE
feat: add TLS/HTTPS via Let's Encrypt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,10 @@ services:
       - traefik.enable=true
       - traefik.http.routers.tilt.rule=Host(`tilt.159.223.26.67.sslip.io`)
       - traefik.http.routers.tilt.entrypoints=http
+      - traefik.http.routers.tilt-https.rule=Host(`tilt.159.223.26.67.sslip.io`)
+      - traefik.http.routers.tilt-https.entrypoints=https
+      - traefik.http.routers.tilt-https.tls=true
+      - traefik.http.routers.tilt-https.tls.certresolver=letsencrypt
       - traefik.http.services.tilt.loadbalancer.server.port=80
     restart: unless-stopped
     networks:


### PR DESCRIPTION
## Summary
- Add HTTPS router to Traefik labels in docker-compose.yml
- Uses existing Let's Encrypt certresolver configured on coolify-proxy
- TLS termination at Traefik level, apps continue serving HTTP internally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled HTTPS support with automatic TLS certificate provisioning via Let's Encrypt for improved security.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jonathangadeaharder/Tilt/pull/266)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->