### PR TITLE
feat(telemetry): thin vendor-agnostic telemetry wrapper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,8 @@ OPENROUTER_MODEL=openai/gpt-4o-mini
 # Groq (set AI_PROVIDER=groq)
 GROQ_API_KEY=
 GROQ_MODEL=llama-3.1-8b-instant
+
+# PostHog Telemetry (Optional)
+PUBLIC_POSTHOG_HOST=https://app.posthog.com
+PUBLIC_POSTHOG_PROJECT_TOKEN=
+

--- a/src/lib/telemetry.test.ts
+++ b/src/lib/telemetry.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+import { captureError, identify, initTelemetry, pageview, reset, track } from './telemetry';
+
+vi.mock('posthog-js', () => ({
+	default: {
+		init: vi.fn(),
+		capture: vi.fn(),
+		identify: vi.fn(),
+		reset: vi.fn()
+	}
+}));
+
+vi.mock('$env/static/public', () => ({
+	PUBLIC_POSTHOG_HOST: 'https://app.posthog.com',
+	PUBLIC_POSTHOG_PROJECT_TOKEN: 'phc_test_token'
+}));
+
+describe('telemetry wrapper', () => {
+	it('initializes and tracks events', () => {
+		expect(() => initTelemetry()).not.toThrow();
+		expect(() => track('test_event', { foo: 'bar' })).not.toThrow();
+		expect(() => pageview('/test')).not.toThrow();
+		expect(() => captureError(new Error('test error'))).not.toThrow();
+		expect(() => identify('user_123', { plan: 'pro' })).not.toThrow();
+		expect(() => reset()).not.toThrow();
+	});
+});

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,0 +1,52 @@
+import posthog from 'posthog-js';
+import { PUBLIC_POSTHOG_HOST, PUBLIC_POSTHOG_PROJECT_TOKEN } from '$env/static/public';
+
+let initialized = false;
+
+export function initTelemetry(): void {
+	if (initialized || typeof window === 'undefined') return;
+	if (PUBLIC_POSTHOG_PROJECT_TOKEN) {
+		posthog.init(PUBLIC_POSTHOG_PROJECT_TOKEN, {
+			api_host: PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
+			loaded: () => {
+				initialized = true;
+			}
+		});
+		initialized = true;
+	}
+}
+
+export function track(eventName: string, properties?: Record<string, unknown>): void {
+	initTelemetry();
+	if (initialized && typeof window !== 'undefined') {
+		posthog.capture(eventName, properties);
+	}
+}
+
+export function pageview(url?: string): void {
+	initTelemetry();
+	if (initialized && typeof window !== 'undefined') {
+		posthog.capture('$pageview', { current_url: url ?? window.location.href });
+	}
+}
+
+export function captureError(error: unknown, context?: Record<string, unknown>): void {
+	initTelemetry();
+	if (initialized && typeof window !== 'undefined') {
+		const message = error instanceof Error ? error.message : String(error);
+		posthog.capture('exception', { message, error, ...context });
+	}
+}
+
+export function identify(distinctId: string, userProperties?: Record<string, unknown>): void {
+	initTelemetry();
+	if (initialized && typeof window !== 'undefined') {
+		posthog.identify(distinctId, userProperties);
+	}
+}
+
+export function reset(): void {
+	if (initialized && typeof window !== 'undefined') {
+		posthog.reset();
+	}
+}


### PR DESCRIPTION
## Summary
Implements  with , , , , and  helper methods, ensuring single entrypoint for PostHog event dispatching.

Resolves #232.