### PR TITLE
chore(env): add PostHog telemetry variables to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,8 @@ OPENROUTER_MODEL=openai/gpt-4o-mini
 # Groq (set AI_PROVIDER=groq)
 GROQ_API_KEY=
 GROQ_MODEL=llama-3.1-8b-instant
+
+# PostHog Telemetry (Optional)
+PUBLIC_POSTHOG_HOST=https://app.posthog.com
+PUBLIC_POSTHOG_PROJECT_TOKEN=
+


### PR DESCRIPTION
## Summary
Adds PUBLIC_POSTHOG_HOST and PUBLIC_POSTHOG_PROJECT_TOKEN to .env.example so SvelteKit generates dynamic environment types.